### PR TITLE
Add mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,0 +1,3 @@
+name = doors
+depends = default
+optional_depends = screwdriver


### PR DESCRIPTION
This will set it up so that Minetest always sees this mod's name as 'doors' regardless of the folder name